### PR TITLE
Retry 5 times to get k8s configuration

### DIFF
--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -78,7 +78,7 @@ resource "null_resource" "local_k8s_context" {
   depends_on = [time_sleep.wait_for_kube]
   provisioner "local-exec" {
     # Update your local gcloud and kubectl credentials for the newly created cluster
-    command = "gcloud container clusters get-credentials ${var.gke_cluster_name} --project=${var.project_id} --zone=${var.zone}"
+    command = "for i in 1 2 3 4 5; do gcloud container clusters get-credentials ${var.gke_cluster_name} --project=${var.project_id} --zone=${var.zone} && break || sleep 60; done"
   }
 }
 


### PR DESCRIPTION
Changes:
- Sometimes k8s configuration fetching fails first time. I added 5 retries 60s apart.

<img src="https://gcdn.pbrd.co/images/ozLX2VVKpeRu.png?o=1" />
