### PR TITLE
Options to run helm with local exec as well

### DIFF
--- a/terraform/load-balancer.tf
+++ b/terraform/load-balancer.tf
@@ -75,7 +75,7 @@ resource "google_compute_region_url_map" "default" {
 
 resource "google_compute_region_backend_service" "default" {
   # This cannot be deployed until the ingress gateway is deployed and the standalone NEG is automatically created
-  depends_on = [helm_release.gloo]
+  depends_on = [null_resource.gloo]
   project = google_compute_subnetwork.default.project
   region  = google_compute_subnetwork.default.region
   name        = "l7-xlb-backend-service-http"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ variable "ip_address_name" {
 }
 
 variable "helm_local_exec" {
-  description = "The name of the static IP Address for the load balancer"
+  description = "Use locally installed helm via exec if true or helm terraform provider if false (default false)"
 }
 
 resource "google_compute_network" "default" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,10 @@ variable "ip_address_name" {
   description = "The name of the static IP Address for the load balancer"
 }
 
+variable "helm_local_exec" {
+  description = "The name of the static IP Address for the load balancer"
+}
+
 resource "google_compute_network" "default" {
   name                    = var.network_name
   auto_create_subnetworks = "false"

--- a/terraform/scripts/install-gloo.sh
+++ b/terraform/scripts/install-gloo.sh
@@ -5,6 +5,6 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 helm repo add gloo https://storage.googleapis.com/solo-public-helm
 helm repo update
 
-helm install --dry-run gloo gloo/gloo \
+helm install gloo gloo/gloo \
   --namespace gloo-system \
   -f "$DIR/values.yaml"

--- a/terraform/scripts/install-gloo.sh
+++ b/terraform/scripts/install-gloo.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+helm repo add gloo https://storage.googleapis.com/solo-public-helm
+helm repo update
+
+helm install --dry-run gloo gloo/gloo \
+  --namespace gloo-system \
+  -f "$DIR/values.yaml"

--- a/terraform/scripts/values.yaml
+++ b/terraform/scripts/values.yaml
@@ -1,0 +1,10 @@
+gatewayProxies:
+  gatewayProxy:
+    service:
+      type: ClusterIP
+      extraAnnotations:
+        cloud.google.com/neg: '{"exposed_ports": {"80":{"name": "ingressgateway"}}}'
+    kind:
+      deployment:
+        replicas: 2
+    antiAffinity: true

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -10,3 +10,4 @@ machine_type     = "e2-standard-2"
 disk_size        = 20
 network_name     = "my-network"
 ip_address_name  = "my-static-ip"
+helm_local_exec  = false


### PR DESCRIPTION
Sometimes helm terraform chart fails. Allow to run the local installed helm with local_exec

<img src="https://gcdn.pbrd.co/images/Of4G9kG7b3YT.png?o=1" />