### PR TITLE
Updated FAQ on HTTP->HTTPS redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ kubectl delete pods --field-selector status.phase=Failed --all-namespaces
 
 7. *What about HTTPS/TLS termination for the Regional HTTP Load Balancer?*
 
-    Implementing HTTPS (including a redirect) is possible, but not currently incorporated into this solution. There is a GitHub issue open [here](https://github.com/murphye/cheap-gke-cluster/issues/1) with details. 
+    See [here](#optional-enable-https) for details
 
 8. *Can I do TCP passthrough rather than HTTP for the Regional Load Balancer?*
 


### PR DESCRIPTION
FAQ had a leftover question on HTTP->HTTPS redirects, linking to an open issue.  That issue has since been closed, and a section added to the README.  I updated the FAQ answer with a link to that section, but it may also be appropriate to simply delete the question.